### PR TITLE
Add toast error messages for errors during setup

### DIFF
--- a/apps/ui/components/setup/CreateDatabase.tsx
+++ b/apps/ui/components/setup/CreateDatabase.tsx
@@ -2,6 +2,7 @@ import { LoadingButton } from '@mui/lab';
 import { Typography } from '@mui/material';
 import React from 'react';
 import { useForm } from 'react-hook-form';
+import {toast} from "react-hot-toast";
 
 import { useCreateDatabase } from '../../hooks/data/setup/useCreateDatabase';
 
@@ -23,8 +24,12 @@ export function CreateDatabase({ onSubmit }: CreateDatabaseProps) {
    * Handle the form submission
    */
   async function handleSubmitForm() {
-    await createDatabase.mutateAsync();
-    onSubmit();
+    try {
+      await createDatabase.mutateAsync();
+      onSubmit();
+    } catch (error) {
+      toast.error(error.message);
+    }
   }
 
   return (

--- a/apps/ui/components/setup/CreateUser.tsx
+++ b/apps/ui/components/setup/CreateUser.tsx
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as yup from 'yup';
+import {toast} from "react-hot-toast";
 
 import { SetupStep } from '@tarrasque/common';
 
@@ -42,9 +43,13 @@ export function CreateUser({ onSubmit }: CreateUserProps) {
    * @param values - The user values
    */
   async function handleSubmitForm(values: Schema) {
-    await signUp.mutateAsync(values);
-    await updateSetup.mutateAsync({ step: SetupStep.COMPLETED, completed: true });
-    onSubmit();
+    try {
+      await signUp.mutateAsync(values);
+      await updateSetup.mutateAsync({step: SetupStep.COMPLETED, completed: true});
+      onSubmit();
+    } catch (error) {
+      toast.error(error.message);
+    }
   }
 
   return (


### PR DESCRIPTION
## Proposed Changes

- Add a toast message on a create-database error and registration error

As of now, if for any reason an error occurs after clicking the Continue button, users could risk not noticing it unless they read the console output.

![immagine](https://github.com/tarrasqueapp/tarrasqueapp/assets/85199411/b79710e9-c4bd-46bc-8398-3818ffdc1c59)

They also might be led to think that there is no problem even after having waited for a long time.

If try catches are used in the submit handlers and toast error messages are displayed if an error is caught, I think the general UX would be improved.

![immagine](https://github.com/tarrasqueapp/tarrasqueapp/assets/85199411/9350518d-ed65-48b3-9faf-874df4d93845)

![immagine](https://github.com/tarrasqueapp/tarrasqueapp/assets/85199411/9d86e943-df56-48f0-8db3-e93f98339dd1)
