### PR TITLE
Fix punycode warning

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -14,10 +15,30 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: pnpm
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm lint

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const content: any;
+  export default content;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,9 @@ const nextConfig = {
           as: '*.js',
         },
       },
+      resolveAlias: {
+        punycode: 'punycode/',
+      },
     },
   },
   webpack(config) {
@@ -54,6 +57,8 @@ const nextConfig = {
 
     // Modify the file loader rule to ignore *.svg, since we have it handled now.
     fileLoaderRule.exclude = /\.svg$/i;
+
+    config.resolve.alias.punycode = require.resolve(`punycode/`);
 
     return config;
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Richard Solomou <richard@tarrasque.app>",
   "scripts": {
     "build": "next build",
-    "dev": "NODE_OPTIONS=--no-deprecation next dev --turbo",
+    "dev": "next dev --turbo",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "tsc --noEmit && next lint",
     "lint-staged": "lint-staged",
@@ -49,6 +49,7 @@
     "nodemailer": "^6.9.9",
     "pixi-viewport": "^5.0.2",
     "pixi.js": "^7.4.0",
+    "punycode": "1.4.1",
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ dependencies:
   pixi.js:
     specifier: ^7.4.0
     version: 7.4.0
+  punycode:
+    specifier: 1.4.1
+    version: 1.4.1
   react:
     specifier: ^18.2.0
     version: 18.2.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tronite/style-guide/typescript/next",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "custom.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "compilerOptions": {
     "target": "ES2015",
     "paths": {

--- a/utils/PlatformUtils.ts
+++ b/utils/PlatformUtils.ts
@@ -79,6 +79,7 @@ export class PlatformUtils {
 
     return (
       'ontouchstart' in window ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ((window as any).DocumentTouch && document instanceof (window as any).DocumentTouch) ||
       navigator.maxTouchPoints > 0
     );


### PR DESCRIPTION
Implement something similar to yarn's approach to temporarily fixing the punycode deprecation warning from https://github.com/yarnpkg/yarn/pull/9009/commits/859d7398b753d22e0e74c3b07ba88c1a566691ae.

This should be reverted when https://github.com/garycourt/uri-js/pull/95 gets merged as it appears to be the source of the problem.